### PR TITLE
一般ユーザーの商品一覧、カート追加機能の実装

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Category;
 

--- a/app/Http/Controllers/Admin/ImportController.php
+++ b/app/Http/Controllers/Admin/ImportController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;  
 use App\Models\Import;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Product;
 use App\Models\ProductImage;
@@ -35,11 +36,7 @@ class ProductController extends Controller
       ->orderByDesc('updated_at')
       ->paginate(15);
 
-    $view = $request->route()->getName() === 'admin.products.index'
-      ? 'products.index'
-      : 'user.products.index';
-
-    return view($view, compact('products', 'categories', 'categoryId', 'search'));
+    return view('products.index', compact('products', 'categories', 'categoryId', 'search'));
   }
 
   /**
@@ -59,12 +56,7 @@ class ProductController extends Controller
     $product = Product::with(['category', 'productImages'])
       ->where('uuid', $uuid)->firstOrFail();
 
-    // ルート名に基づいてビューを切り替え
-    $view = $request->route()->getName() === 'admin.products.show'
-      ? 'products.show'
-      : 'user.products.show';
-
-    return view($view, compact('product'));
+    return view('products.show', compact('product'));
   }
 
   /**

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -16,9 +16,6 @@ use Illuminate\Support\Facades\Auth;
 use App\Models\Import;
 use App\Jobs\ImportProductsJob;
 
-// CSVライブラリ読み込み https://csv.thephpleague.com/
-use League\Csv\Reader;
-
 class ProductController extends Controller
 {
   /**
@@ -77,7 +74,7 @@ class ProductController extends Controller
   {
     // トランザクション開始（画像保存に失敗したら商品も作成しない）
     DB::beginTransaction();
-
+    
     try {
       // 商品レコードを作成（画像以外）
       $product = Product::create([

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -38,7 +38,11 @@ class ProductController extends Controller
       ->orderByDesc('updated_at')
       ->paginate(15);
 
-    return view('products.index', compact('products', 'categories', 'categoryId', 'search'));
+    $view = $request->route()->getName() === 'admin.products.index'
+      ? 'products.index'
+      : 'user.products.index';
+
+    return view($view, compact('products', 'categories', 'categoryId', 'search'));
   }
 
   /**
@@ -53,12 +57,17 @@ class ProductController extends Controller
   /**
    * Display the specified resource.
    */
-  public function show(string $uuid)
+  public function show(Request $request, string $uuid)
   {
     $product = Product::with(['category', 'productImages'])
       ->where('uuid', $uuid)->firstOrFail();
 
-    return view('products.show', compact('product'));
+    // ルート名に基づいてビューを切り替え
+    $view = $request->route()->getName() === 'admin.products.show'
+      ? 'products.show'
+      : 'user.products.show';
+
+    return view($view, compact('product'));
   }
 
   /**
@@ -248,7 +257,6 @@ class ProductController extends Controller
       return redirect()->route('admin.products.index')
         ->with('success', 'CSVインポート処理を受け付けました')
         ->with('import_id', $import->id);
-
     } catch (\Exception $e) {
       Log::error('CSV Import Error: ' . $e->getMessage());
       return redirect()->route('admin.products.index')

--- a/app/Http/Controllers/User/CartController.php
+++ b/app/Http/Controllers/User/CartController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Product;
+
+class CartController extends Controller
+{
+  // カートに追加
+  public function add(Request $request)
+  {
+    $product = Product::with(['mainImage', 'category'])->findOrFail($request->product_id);
+
+    $cartItem = [
+      'product_id' => $product->id,
+      'product_name' => $product->name,
+      'quantity' => $request->quantity ?? 1,
+      'unit_price' => $product->price,
+      'image_path' => $product->mainImage ? $product->mainImage->image_path : null,
+      'category_name' => $product->category->name
+    ];
+
+    $cart = $request->session()->get('cart', []);
+
+    // 既に同じ商品がカートにある場合は数量を加算
+    if (isset($cart[$product->id])) {
+      $cart[$product->id]['quantity'] += $cartItem['quantity'];
+    } else {
+      $cart[$product->id] = $cartItem;
+    }
+
+    $request->session()->put('cart', $cart);
+
+    return redirect()->back()->with('success', 'カートに追加しました');
+  }
+
+  // カート表示
+  public function index(Request $request)
+  {
+    $cart = $request->session()->get('cart', []);
+
+    return view('user.cart.index', compact('cart'));
+  }
+
+  // カートの商品を削除
+  public function remove(Request $request, $productId)
+  {
+    $cart = $request->session()->get('cart', []);
+
+    if (isset($cart[$productId])) {
+      unset($cart[$productId]);
+      $request->session()->put('cart', $cart);
+      return redirect()->back()->with('success', 'カートから削除しました');
+    }
+
+    return redirect()->back()->with('error', '商品が見つかりませんでした');
+  }
+
+  /*** 
+  カートの商品を増減させる("-"と"+"アイコンを押したときの動き) 
+   ***/
+  public function update(Request $request, $productId)
+  {
+    $cart = $request->session()->get('cart', []);
+
+    if (!isset($cart[$productId])) {
+      return response()->json([
+        'success' => false,
+        'message' => '商品が見つかりませんでした'
+      ], 404);
+    }
+
+    $action = $request->input('action');
+
+    if ($action === 'increment') {
+      $cart[$productId]['quantity']++;
+    } elseif ($action === 'decrement') {
+      if ($cart[$productId]['quantity'] > 1) {
+        $cart[$productId]['quantity']--;
+      }
+    }
+
+    $request->session()->put('cart', $cart);
+
+    // JSON形式でレスポンスを返す
+    return response()->json([
+      'success' => true,
+      'quantity' => $cart[$productId]['quantity'],
+      'subtotal' => $cart[$productId]['unit_price'] * $cart[$productId]['quantity'],
+      'message' => '数量を更新しました'
+    ]);
+  }
+
+  /*** 
+  カート内の商品数をカウントする
+   ***/
+  public function count(Request $request)
+  {
+    $cart = $request->session()->get('cart', []);
+    $totalQuantity = 0;
+
+    foreach ($cart as $item) {
+      $totalQuantity += $item['quantity'];
+    }
+
+    return response()->json(['count' => $totalQuantity]);
+  }
+}

--- a/app/Http/Controllers/User/CartController.php
+++ b/app/Http/Controllers/User/CartController.php
@@ -5,18 +5,63 @@ namespace App\Http\Controllers\User;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Product;
+use App\Http\Requests\CartAddRequest;
 
 class CartController extends Controller
 {
-  // カートに追加
-  public function add(Request $request)
+  /***
+   * カート表示
+   ***/
+  public function index(Request $request)
   {
-    $product = Product::with(['mainImage', 'category'])->findOrFail($request->product_id);
+    $cart = $request->session()->get('cart', []);
+
+    // ビジネスロジックをController側で処理
+    $totalQuantity = $this->calculateTotalQuantity($cart);
+    $totalPrice = $this->calculateTotalPrice($cart);
+
+    return view('user.cart.index', compact('cart', 'totalQuantity', 'totalPrice'));
+  }
+
+  /**
+   * カート内の合計数量を計算(プライベートメソッド)
+   */
+  private function calculateTotalQuantity(array $cart): int
+  {
+    $total = 0;
+    foreach ($cart as $item) {
+      $total += $item['quantity'];
+    }
+    return $total;
+  }
+
+  /**
+   * カート内の合計金額を計算(プライベートメソッド)
+   */
+  private function calculateTotalPrice(array $cart): int
+  {
+    $total = 0;
+    foreach ($cart as $item) {
+      $total += $item['unit_price'] * $item['quantity'];
+    }
+    return $total;
+  }
+
+  /***
+   * カートに追加
+   ****/
+  public function add(CartAddRequest $request)
+  {
+    // バリデーション
+    $validated = $request->validated();
+
+    $product = Product::with(['mainImage', 'category'])
+      ->findOrFail($request->product_id);
 
     $cartItem = [
       'product_id' => $product->id,
       'product_name' => $product->name,
-      'quantity' => $request->quantity ?? 1,
+      'quantity' => $validated['quantity'],  // バリデーション済みの値を使用
       'unit_price' => $product->price,
       'image_path' => $product->mainImage ? $product->mainImage->image_path : null,
       'category_name' => $product->category->name
@@ -24,9 +69,13 @@ class CartController extends Controller
 
     $cart = $request->session()->get('cart', []);
 
-    // 既に同じ商品がカートにある場合は数量を加算
     if (isset($cart[$product->id])) {
-      $cart[$product->id]['quantity'] += $cartItem['quantity'];
+      // 既存の数量と新規の数量の合計をチェック
+      $newQuantity = $cart[$product->id]['quantity'] + $validated['quantity'];
+      if ($newQuantity > 99) {
+        return redirect()->back()->with('error', 'カート内の数量は最大99までです');
+      }
+      $cart[$product->id]['quantity'] = $newQuantity;
     } else {
       $cart[$product->id] = $cartItem;
     }
@@ -36,15 +85,9 @@ class CartController extends Controller
     return redirect()->back()->with('success', 'カートに追加しました');
   }
 
-  // カート表示
-  public function index(Request $request)
-  {
-    $cart = $request->session()->get('cart', []);
-
-    return view('user.cart.index', compact('cart'));
-  }
-
-  // カートの商品を削除
+  /***
+   * カートの商品を削除
+   ***/
   public function remove(Request $request, $productId)
   {
     $cart = $request->session()->get('cart', []);
@@ -58,39 +101,62 @@ class CartController extends Controller
     return redirect()->back()->with('error', '商品が見つかりませんでした');
   }
 
-  /*** 
-  カートの商品を増減させる("-"と"+"アイコンを押したときの動き) 
-   ***/
-  public function update(Request $request, $productId)
+  /**
+   * 数量を増やす("+"を押したときの動き)
+   */
+  public function increment(Request $request, $productId)
+  {
+    return response()->json(
+      $this->updateQuantity($request, $productId, 1)
+    );
+  }
+
+  /**
+   * 数量を減らす("-"を押したときの動き)
+   */
+  public function decrement(Request $request, $productId)
+  {
+    return response()->json(
+      $this->updateQuantity($request, $productId, -1)
+    );
+  }
+
+  /**
+   * 数量更新の共通処理（プライベートメソッド）
+   */
+  private function updateQuantity(Request $request, $productId, $delta): array
   {
     $cart = $request->session()->get('cart', []);
 
     if (!isset($cart[$productId])) {
-      return response()->json([
-        'success' => false,
-        'message' => '商品が見つかりませんでした'
-      ], 404);
+      abort(404, '商品が見つかりませんでした');
     }
 
-    $action = $request->input('action');
-
-    if ($action === 'increment') {
-      $cart[$productId]['quantity']++;
-    } elseif ($action === 'decrement') {
-      if ($cart[$productId]['quantity'] > 1) {
-        $cart[$productId]['quantity']--;
-      }
+    // 減少の場合は最小値チェック
+    if ($delta < 0 && $cart[$productId]['quantity'] <= 1) {
+      abort(400, '数量は1以上である必要があります');
     }
 
+    // 数量を更新
+    $cart[$productId]['quantity'] += $delta;
+
+    // セッションに保存
     $request->session()->put('cart', $cart);
 
-    // JSON形式でレスポンスを返す
-    return response()->json([
-      'success' => true,
+    // カート全体の合計金額を計算
+    $totalPrice = 0;
+    $totalQuantity = 0;
+    foreach ($cart as $item) {
+      $totalPrice += $item['unit_price'] * $item['quantity'];
+      $totalQuantity += $item['quantity'];
+    }
+
+    return [
       'quantity' => $cart[$productId]['quantity'],
       'subtotal' => $cart[$productId]['unit_price'] * $cart[$productId]['quantity'],
-      'message' => '数量を更新しました'
-    ]);
+      'total_price' => $totalPrice,
+      'total_quantity' => $totalQuantity
+    ];
   }
 
   /*** 

--- a/app/Http/Controllers/User/ProductController.php
+++ b/app/Http/Controllers/User/ProductController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Http\Request;
+
+class ProductController extends Controller
+{
+    /**
+     * ユーザー画面: 商品一覧
+     */
+    public function index(Request $request)
+    {
+        $categories = Category::getOrderedCategories();
+        
+        // 検索条件を取得
+        $search = $request->input('search');
+        $categoryId = $request->input('category_id');
+        
+        // 商品を検索・取得
+        $products = Product::search($search, $categoryId)
+            ->with(['mainImage'])
+            ->orderByDesc('updated_at')
+            ->paginate(15);
+        
+        return view('user.products.index', compact('products', 'categories', 'categoryId', 'search'));
+    }
+    
+    /**
+     * ユーザー画面: 商品詳細
+     */
+    public function show(string $uuid)
+    {
+        $product = Product::with(['category', 'productImages'])
+            ->where('uuid', $uuid)
+            ->firstOrFail();
+        
+        return view('user.products.show', compact('product'));
+    }
+}

--- a/app/Http/Requests/CartAddRequest.php
+++ b/app/Http/Requests/CartAddRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CartAddRequest extends FormRequest
+{
+    /**
+     * リクエストが認証されているかを判定
+     */
+    public function authorize(): bool
+    {
+        // 未ログインでも購入可能なので true
+        return true;
+    }
+
+    /**
+     * バリデーションルール
+     */
+    public function rules(): array
+    {
+        return [
+            'product_id' => [
+                'required',
+                'integer',
+                'exists:products,id'
+            ],
+            'quantity' => [
+                'required',
+                'integer',
+                'min:1',
+                'max:99'
+            ]
+        ];
+    }
+
+    /**
+     * カスタムエラーメッセージ
+     */
+    public function messages(): array
+    {
+        return [
+            'product_id.required' => '商品IDは必須です',
+            'product_id.integer' => '商品IDは整数である必要があります',
+            'product_id.exists' => '指定された商品が存在しません',
+            'quantity.required' => '数量は必須です',
+            'quantity.integer' => '数量は整数で入力してください',
+            'quantity.min' => '数量は1以上で入力してください',
+            'quantity.max' => '数量は99以下で入力してください'
+        ];
+    }
+
+    /**
+     * バリデーション失敗時の属性名
+     */
+    public function attributes(): array
+    {
+        return [
+            'product_id' => '商品ID',
+            'quantity' => '数量'
+        ];
+    }
+}

--- a/app/Http/Requests/ProductStoreRequest.php
+++ b/app/Http/Requests/ProductStoreRequest.php
@@ -30,7 +30,6 @@ class ProductStoreRequest extends FormRequest
       'main_image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
       'sub_image_1' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
       'sub_image_2' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
-      'csv_file' => 'required|file|mimes:csv,txt|max:2048'
     ];
   }
   

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -12,20 +12,26 @@
 
         <!-- Navigation Links -->
         <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
+          @auth
           <x-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.dashboard')">
             {{ __('Dashboard') }}
           </x-nav-link>
+          @else
+          <x-nav-link :href="route('user.dashboard')" :active="request()->routeIs('user.dashboard')">
+            {{ __('Dashboard') }}
+          </x-nav-link>
+          @endauth
         </div>
       </div>
 
       <!-- Settings Dropdown -->
+      @auth
       <div class="hidden sm:flex sm:items-center sm:ms-6">
         <x-dropdown align="right" width="48">
           <x-slot name="trigger">
             <button
               class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
               <div>{{ Auth::user()->name }}</div>
-
               <div class="ms-1">
                 <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                   <path fill-rule="evenodd"
@@ -53,6 +59,7 @@
           </x-slot>
         </x-dropdown>
       </div>
+      @endauth
 
       <!-- Hamburger -->
       <div class="-me-2 flex items-center sm:hidden">
@@ -72,16 +79,27 @@
   <!-- Responsive Navigation Menu -->
   <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
     <div class="pt-2 pb-3 space-y-1">
+      @auth
       <x-responsive-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.dashboard')">
         {{ __('Dashboard') }}
       </x-responsive-nav-link>
+      @else
+      <x-responsive-nav-link :href="route('user.dashboard')" :active="request()->routeIs('user.dashboard')">
+        {{ __('Dashboard') }}
+      </x-responsive-nav-link>
+      @endauth
     </div>
 
     <!-- Responsive Settings Options -->
+    @auth
     <div class="pt-4 pb-1 border-t border-gray-200">
       <div class="px-4">
-        <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-        <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
+        <div class="font-medium text-base text-gray-800">
+          {{ Auth::user()->name }}
+        </div>
+        <div class="font-medium text-sm text-gray-500">
+          {{ Auth::user()->email }}
+        </div>
       </div>
 
       <div class="mt-3 space-y-1">
@@ -100,5 +118,6 @@
         </form>
       </div>
     </div>
+    @endauth
   </div>
 </nav>

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -4,7 +4,20 @@
       商品登録
     </h2>
   </x-slot>
-
+  <!-- バリデーションエラー（フィールド単位） -->
+  @if ($errors->any())
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+      <strong class="font-bold">エラーが発生しました:</strong>
+      <ul class="mt-2 list-disc list-inside">
+        @foreach ($errors->all() as $error)
+        <li>{{ $error }}</li>
+        @endforeach
+      </ul>
+    </div>
+  </div>
+  @endif
+  <!-- システムエラー（例外処理など） -->
   @if (session('error'))
   <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
     <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">

--- a/resources/views/user/cart/index.blade.php
+++ b/resources/views/user/cart/index.blade.php
@@ -8,14 +8,6 @@
       <a href="{{ route('user.cart.index') }}"
         class="relative text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded">
         カート
-        @php
-        $totalQuantity = 0;
-        if(session('cart')) {
-        foreach(session('cart') as $item) {
-        $totalQuantity += $item['quantity'];
-        }
-        }
-        @endphp
         @if($totalQuantity > 0)
         <span id="cart-badge"
           class="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold rounded-full h-6 w-6 flex items-center justify-center">
@@ -69,6 +61,15 @@
                 戻る</a>
             </div>
             <div class="container px-5 py-24 mx-auto">
+              @if(empty($cart))
+              <div class="text-center py-12">
+                <p class="text-gray-600 text-lg mb-6">カートに商品がありません</p>
+                <a href="{{ route('user.products.index') }}"
+                  class="text-white bg-indigo-500 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded">
+                  商品一覧へ
+                </a>
+              </div>
+              @else
               <div class="flex flex-wrap -m-4">
                 @foreach($cart as $productId => $item)
                 <div class="p-4 md:w-1/3">
@@ -128,6 +129,29 @@
                 </div>
                 @endforeach
               </div>
+              {{-- 合計金額表示--}}
+              <div class="mt-8 border-t pt-8">
+                <div class="max-w-lg ml-auto">
+                  <div class="bg-gray-50 p-6 rounded-lg">
+                    <div class="flex justify-between items-center mb-4">
+                      <span class="text-lg font-medium text-gray-700">合計</span>
+                      <span class="text-xl font-semibold" id="cart-total-price">
+                        {{ number_format($totalPrice) }} 円
+                      </span>
+                    </div>
+                    <div class="flex justify-between items-center mb-6 pb-6 border-b">
+                      <span class="text-lg font-medium text-gray-700">商品点数</span>
+                      <span class="text-lg" id="total-quantity">{{ $totalQuantity }}点</span>
+                    </div>
+                    <a href=""
+                      class="block w-full text-center text-white bg-indigo-500 border-0 py-3 px-6 focus:outline-none hover:bg-indigo-600 rounded text-lg">
+                      購入手続きへ進む
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+              @endif
             </div>
           </section>
 
@@ -141,39 +165,61 @@
     const productId = button.dataset.productId;
     const action = button.dataset.action;
 
-    const quantityElement = document.getElementById(`quantity-${productId}`);
-    const subtotalElement = document.getElementById(`subtotal-${productId}`);
-    const decrementButton = document.getElementById(`decrement-${productId}`);
+    // アクションに応じてエンドポイントを決定
+    const endpoint = action === 'increment' ?
+      `{{ url('cart') }}/${productId}/increment` :
+      `{{ url('cart') }}/${productId}/decrement`;
 
-    fetch(`{{ url('cart/update') }}/${productId}`, {
+    fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-CSRF-TOKEN': '{{ csrf_token() }}'
-        },
-        body: JSON.stringify({
-          action: action
-        })
-      })
-      .then(response => response.json())
-      .then(data => {
-        if (data.success) {
-          quantityElement.textContent = data.quantity;
-          subtotalElement.textContent = `小計: ${data.subtotal.toLocaleString()} 円`;
-
-          if (data.quantity <= 1) {
-            decrementButton.disabled = true;
-            decrementButton.classList.add('opacity-50', 'cursor-not-allowed');
-          } else {
-            decrementButton.disabled = false;
-            decrementButton.classList.remove('opacity-50', 'cursor-not-allowed');
-          }
-
-          // バッジを更新
-          updateCartBadge();
-        } else {
-          alert(data.message);
         }
+      })
+      .then(response => {
+        if (!response.ok) { // HTTPステータスで判定
+          return response.json().then(data => {
+            throw new Error(data.message || '更新に失敗しました');
+          });
+        }
+        return response.json();
+      })
+      .then(data => {
+        // ここに来た時点で成功確定
+        const quantityElement = document.getElementById(`quantity-${productId}`);
+        const subtotalElement = document.getElementById(`subtotal-${productId}`);
+        const decrementButton = document.getElementById(`decrement-${productId}`);
+        const totalPriceElement = document.getElementById('cart-total-price');
+        const totalQuantityElement = document.getElementById('total-quantity');
+
+        // 個別商品の数量と小計を更新
+        quantityElement.textContent = data.quantity;
+        subtotalElement.textContent = `小計: ${data.subtotal.toLocaleString()} 円`;
+
+        // カート全体の合計金額を更新
+        if (totalPriceElement) {
+          totalPriceElement.textContent = `${data.total_price.toLocaleString()} 円`;
+        }
+
+        // 商品点数を更新
+        if (totalQuantityElement) {
+          totalQuantityElement.textContent = `${data.total_quantity}点`;
+        }
+
+        // マイナスボタンの制御
+        if (data.quantity <= 1) {
+          decrementButton.disabled = true;
+          decrementButton.classList.add('opacity-50', 'cursor-not-allowed');
+        } else {
+          decrementButton.disabled = false;
+          decrementButton.classList.remove('opacity-50', 'cursor-not-allowed');
+        }
+
+        // バッジを更新
+        updateCartBadge();
+
+
       })
       .catch(error => {
         console.error('エラー:', error);
@@ -197,7 +243,8 @@
         }
       })
       .catch(error => {
-        console.error('バッジ更新エラー:', error);
+        console.error('エラー:', error);
+        alert(error.message);
       });
   }
   </script>

--- a/resources/views/user/cart/index.blade.php
+++ b/resources/views/user/cart/index.blade.php
@@ -1,0 +1,204 @@
+<x-app-layout>
+  <x-slot name="header">
+    <div class="flex justify-between items-center">
+      <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        カート一覧
+      </h2>
+
+      <a href="{{ route('user.cart.index') }}"
+        class="relative text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded">
+        カート
+        @php
+        $totalQuantity = 0;
+        if(session('cart')) {
+        foreach(session('cart') as $item) {
+        $totalQuantity += $item['quantity'];
+        }
+        }
+        @endphp
+        @if($totalQuantity > 0)
+        <span id="cart-badge"
+          class="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold rounded-full h-6 w-6 flex items-center justify-center">
+          {{ $totalQuantity }}
+        </span>
+        @endif
+      </a>
+
+    </div>
+  </x-slot>
+
+  @if (session('success'))
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+      <span class="block sm:inline">{{ session('success') }}</span>
+    </div>
+  </div>
+  @endif
+  <!-- システムエラー（例外処理など） -->
+  @if (session('error'))
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+      <span class="block sm:inline">{{ session('error') }}</span>
+    </div>
+  </div>
+  @endif
+  <!-- バリデーションエラー（フィールド単位） -->
+  @if ($errors->any())
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+      <strong class="font-bold">入力内容にエラーがあります:</strong>
+      <ul class="mt-2 list-disc list-inside">
+        @foreach ($errors->all() as $error)
+        <li>{{ $error }}</li>
+        @endforeach
+      </ul>
+    </div>
+  </div>
+  @endif
+
+  <div class="py-12">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+        <div class="p-6 text-gray-900">
+
+          <section class="text-gray-600 body-font">
+            <!-- 戻るボタン -->
+            <div class="flex mb-4 justify-start w-full">
+              <a href="{{ route('user.products.index') }}"
+                class="flex text-white bg-gray-500 border-0 py-2 px-6 focus:outline-none hover:bg-gray-600 rounded">
+                戻る</a>
+            </div>
+            <div class="container px-5 py-24 mx-auto">
+              <div class="flex flex-wrap -m-4">
+                @foreach($cart as $productId => $item)
+                <div class="p-4 md:w-1/3">
+                  <div class="h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden">
+                    <img class="lg:h-48 md:h-36 w-full object-cover object-center"
+                      src="{{ $item['image_path'] ? Storage::url($item['image_path']) : asset('images/products/no-image.jpg') }}"
+                      alt="商品画像">
+                    <div class="p-6">
+                      <h2 class="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">
+                        {{ $item['category_name'] }}
+                      </h2>
+                      <h1 class="title-font text-lg font-medium text-gray-900 mb-3">{{ $item['product_name'] }}</h1>
+                      <p class="leading-relaxed mb-3">
+                        {{ number_format($item['unit_price']) }} 円
+                      </p>
+
+                      <div class="mb-3">
+                        <div class="flex items-center space-x-2">
+                          <button onclick="updateQuantity(this)" data-product-id="{{ $productId }}"
+                            data-action="decrement"
+                            class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-1 px-3 rounded"
+                            id="decrement-{{ $productId }}" {{ $item['quantity'] <= 1 ? 'disabled' : '' }}>
+                            -
+                          </button>
+
+                          <span class="text-base font-nomal w-5 text-center" id="quantity-{{ $productId }}">
+                            {{ $item['quantity'] }}
+                          </span>
+
+                          <button onclick="updateQuantity(this)" data-product-id="{{ $productId }}"
+                            data-action="increment"
+                            class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-1 px-3 rounded"
+                            id="increment-{{ $productId }}">
+                            +
+                          </button>
+                        </div>
+                      </div>
+
+                      <p class="leading-relaxed mb-3 font-semibold" id="subtotal-{{ $productId }}">
+                        小計: {{ number_format($item['unit_price'] * $item['quantity']) }} 円
+                      </p>
+
+
+                      <div class="flex items-center justify-between">
+                        <form method="POST" action="{{ route('user.cart.remove', ['productId' => $productId]) }}"
+                          class="inline">
+                          @csrf
+                          @method('DELETE')
+                          <button type="submit" class="text-red-500 inline-flex items-center md:mb-2 lg:mb-0">
+                            削除
+                          </button>
+                        </form>
+
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                @endforeach
+              </div>
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  function updateQuantity(button) {
+    const productId = button.dataset.productId;
+    const action = button.dataset.action;
+
+    const quantityElement = document.getElementById(`quantity-${productId}`);
+    const subtotalElement = document.getElementById(`subtotal-${productId}`);
+    const decrementButton = document.getElementById(`decrement-${productId}`);
+
+    fetch(`{{ url('cart/update') }}/${productId}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': '{{ csrf_token() }}'
+        },
+        body: JSON.stringify({
+          action: action
+        })
+      })
+      .then(response => response.json())
+      .then(data => {
+        if (data.success) {
+          quantityElement.textContent = data.quantity;
+          subtotalElement.textContent = `小計: ${data.subtotal.toLocaleString()} 円`;
+
+          if (data.quantity <= 1) {
+            decrementButton.disabled = true;
+            decrementButton.classList.add('opacity-50', 'cursor-not-allowed');
+          } else {
+            decrementButton.disabled = false;
+            decrementButton.classList.remove('opacity-50', 'cursor-not-allowed');
+          }
+
+          // バッジを更新
+          updateCartBadge();
+        } else {
+          alert(data.message);
+        }
+      })
+      .catch(error => {
+        console.error('エラー:', error);
+        alert('更新に失敗しました。もう一度お試しください。');
+      });
+  }
+
+  // バッジを更新する関数
+  function updateCartBadge() {
+    fetch('{{ route("user.cart.count") }}')
+      .then(response => response.json())
+      .then(data => {
+        const badge = document.getElementById('cart-badge');
+        if (badge) {
+          if (data.count > 0) {
+            badge.textContent = data.count;
+            badge.style.display = 'flex'; // 表示
+          } else {
+            badge.style.display = 'none'; // 非表示
+          }
+        }
+      })
+      .catch(error => {
+        console.error('バッジ更新エラー:', error);
+      });
+  }
+  </script>
+</x-app-layout>

--- a/resources/views/user/dashboard.blade.php
+++ b/resources/views/user/dashboard.blade.php
@@ -32,7 +32,6 @@
                 </div>
               </a>
 
-
             </div>
           </div>
         </section>

--- a/resources/views/user/dashboard.blade.php
+++ b/resources/views/user/dashboard.blade.php
@@ -1,1 +1,44 @@
-ユーザーの管理画面
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+      {{ __('Dashboard') }}
+    </h2>
+  </x-slot>
+
+  <div class="py-12">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+
+
+        <section class="text-gray-600 body-font">
+          <div class="container px-5 py-24 mx-auto">
+            <div class="flex flex-wrap -m-2">
+
+              <a href="{{ route('user.products.index') }}" class="p-2 lg:w-1/3 md:w-1/2 w-full">
+                <div
+                  class="h-full flex items-center border-gray-200 border p-4 rounded-lg hover:bg-gray-100 hover:shadow-md transition-all duration-300">
+                  <div class="flex-grow">
+                    <p class="text-gray-900 title-font font-medium">商品一覧</p>
+                  </div>
+                </div>
+              </a>
+
+              <a href="" class="p-2 lg:w-1/3 md:w-1/2 w-full">
+                <div
+                  class="h-full flex items-center border-gray-200 border p-4 rounded-lg hover:bg-gray-100 hover:shadow-md transition-all duration-300">
+                  <div class="flex-grow">
+                    <p class="text-gray-900 title-font font-medium">カテゴリ一覧</p>
+                  </div>
+                </div>
+              </a>
+
+
+            </div>
+          </div>
+        </section>
+
+
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/user/products/index.blade.php
+++ b/resources/views/user/products/index.blade.php
@@ -4,6 +4,24 @@
       <h2 class="font-semibold text-xl text-gray-800 leading-tight">
         商品一覧
       </h2>
+      <a href="{{ route('user.cart.index') }}"
+        class="relative text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded">
+        カートを見る
+        @php
+        $totalQuantity = 0;
+        if(session('cart')) {
+        foreach(session('cart') as $item) {
+        $totalQuantity += $item['quantity'];
+        }
+        }
+        @endphp
+        @if($totalQuantity > 0)
+        <span
+          class="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold rounded-full h-6 w-6 flex items-center justify-center">
+          {{ $totalQuantity }}
+        </span>
+        @endif
+      </a>
     </div>
   </x-slot>
 
@@ -67,7 +85,7 @@
                       <p class="leading-relaxed mb-3">
                         {{ number_format($product->price) }} 円
                       </p>
-                      <div class="flex items-center flex-wrap ">
+                      <div class="flex items-center justify-between">
                         <a class="text-indigo-500 inline-flex items-center md:mb-2 lg:mb-0"
                           href="{{ route('user.products.show', [ 'uuid' => $product->uuid ]) }}"> 詳細
                           <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
@@ -76,6 +94,14 @@
                             <path d="M12 5l7 7-7 7"></path>
                           </svg>
                         </a>
+                        <form method="POST" action="{{ route('user.cart.add') }}" class="inline">
+                          @csrf
+                          <input type="hidden" name="product_id" value="{{ $product->id }}">
+                          <input type="hidden" name="quantity" value="1">
+                          <button type="submit" class="text-indigo-500 inline-flex items-center md:mb-2 lg:mb-0">
+                            カートに追加
+                          </button>
+                        </form>
                       </div>
                     </div>
                   </div>

--- a/resources/views/user/products/index.blade.php
+++ b/resources/views/user/products/index.blade.php
@@ -1,0 +1,93 @@
+<x-app-layout>
+  <x-slot name="header">
+    <div class="flex justify-between items-center">
+      <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        商品一覧
+      </h2>
+    </div>
+  </x-slot>
+
+  @if (session('success'))
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+      <span class="block sm:inline">{{ session('success') }}</span>
+    </div>
+  </div>
+  @endif
+
+  @if (session('error'))
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+      <span class="block sm:inline">{{ session('error') }}</span>
+    </div>
+  </div>
+  @endif
+
+  <div class="py-12">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+        <div class="p-6 text-gray-900">
+
+          <!-- 検索フォーム -->
+          <form method="get" action="{{route('user.products.index')}}">
+            <div class="flex mb-4 justify-center items-center w-2/3 gap-1 mx-auto">
+              <select id="category_id" name="category_id"
+                class="pr-7 text-sm border border-gray-300 rounded pl-2 py-2 focus:outline-none focus:ring-2"
+                style="width: auto !important;">
+                <option value="">全て</option>
+                @foreach($categories ?? [] as $category)
+                <option value=" {{ $category->id }}"
+                  {{ (string)old('category_id', $categoryId) === (string)$category->id ? 'selected' : '' }}>
+                  {{ $category->name }}
+                </option>
+                @endforeach
+              </select>
+              <input class="flex-1 border border-gray-300 rounded px-4 py-2 focus:outline-none focus:ring-2" type="text"
+                name="search" placeholder="商品検索" value="{{ old('search' , $search) }}">
+              <button class="flex-shrink-0 text-white bg-blue-500 border-0 py-2 px-2 focus:outline-none hover:bg-blue-600 rounded
+                text-lg">検索</button>
+            </div>
+          </form>
+
+          <section class="text-gray-600 body-font">
+            <div class="container px-5 py-24 mx-auto">
+
+              <div class="flex flex-wrap -m-4">
+                @foreach($products as $product)
+                <div class="p-4 md:w-1/3">
+                  <div class="h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden">
+                    <img class="lg:h-48 md:h-36 w-full object-cover object-center"
+                      src="{{ $product->mainImage ? Storage::url($product->mainImage->image_path) : asset('images/products/no-image.jpg') }}"
+                      alt="商品画像">
+                    <div class="p-6">
+                      <h2 class="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">
+                        {{$product->category->name}}
+                      </h2>
+                      <h1 class="title-font text-lg font-medium text-gray-900 mb-3">{{ $product->name }}</h1>
+                      <p class="leading-relaxed mb-3">
+                        {{ number_format($product->price) }} 円
+                      </p>
+                      <div class="flex items-center flex-wrap ">
+                        <a class="text-indigo-500 inline-flex items-center md:mb-2 lg:mb-0"
+                          href="{{ route('user.products.show', [ 'uuid' => $product->uuid ]) }}"> 詳細
+                          <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+                            fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M5 12h14"></path>
+                            <path d="M12 5l7 7-7 7"></path>
+                          </svg>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                @endforeach
+              </div>
+            </div>
+          </section>
+          {{ $products->links() }}
+
+        </div>
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/user/products/show.blade.php
+++ b/resources/views/user/products/show.blade.php
@@ -1,0 +1,85 @@
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+      商品詳細
+    </h2>
+  </x-slot>
+
+  @if (session('success'))
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+      <span class="block sm:inline">{{ session('success') }}</span>
+    </div>
+  </div>
+  @endif
+
+  @if (session('error'))
+  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 pt-4">
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+      <span class="block sm:inline">{{ session('error') }}</span>
+    </div>
+  </div>
+  @endif
+
+  <div class="py-12">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+        <div class="p-6 text-gray-900">
+
+          <section class="text-gray-600 body-font overflow-hidden">
+            <!-- 戻るボタン -->
+            <div class="flex mb-4 justify-start w-full">
+              <a href="{{ route('user.products.index') }}"
+                class="flex text-white bg-gray-500 border-0 py-2 px-6 focus:outline-none hover:bg-gray-600 rounded">
+                戻る</a>
+            </div>
+            <div class="container px-5 py-24 mx-auto">
+
+              <div class="lg:w-[95%] mx-auto flex flex-wrap">
+
+                <!-- 画像エリア: 左側に小さい2つ、右側に大きい1つ -->
+                <div class="lg:w-[60%] w-full flex aspect-[4/3]">
+                  <!-- 左側: 小さい2つの画像を縦並び -->
+                  <div class="flex flex-col w-[25%]">
+                    <div class="md:p-2 p-1">
+                      <img alt="ecommerce" class="w-full aspect-square object-cover object-center block rounded"
+                        src="{{ $product->subImage1 ? Storage::url($product->subImage1->image_path) : asset('images/products/no-image.jpg') }}">
+                    </div>
+                    <div class="md:p-2 p-1">
+                      <img alt="ecommerce" class="w-full aspect-square object-cover object-center block rounded"
+                        src="{{ $product->subImage2 ? Storage::url($product->subImage2->image_path) : asset('images/products/no-image.jpg') }}">
+                    </div>
+                  </div>
+                  <!-- 右側: 大きい1つの画像 -->
+                  <div class="md:p-2 p-1 w-[75%]">
+                    <img alt="ecommerce" class="w-full h-full object-cover object-center block rounded"
+                      src="{{ $product->mainImage ? Storage::url($product->mainImage->image_path) : asset('images/products/no-image.jpg') }}">
+                  </div>
+                </div>
+
+                <!-- 商品情報エリア -->
+                <div class="lg:w-[40%] w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0">
+                  <h2 class="text-sm title-font text-gray-500 tracking-widest">{{ $product->category->name }}</h2>
+                  <h1 class="text-gray-900 text-3xl title-font font-medium mb-1">{{ $product->name }}</h1>
+                  <div class="flex mb-4">
+
+                  </div>
+                  <p class="leading-relaxed">{{ $product->description }}</p>
+                  <div class="flex mt-6 items-center pb-5 border-b-2 border-gray-100 mb-5">
+
+                  </div>
+                  <div class="flex">
+                    <span class="title-font font-medium text-2xl text-gray-900">{{ number_format( $product->price ) }}
+                      円</span>
+                  </div>
+
+                </div>
+              </div>
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,11 +2,12 @@
 
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\ProductController;
-use App\Http\Controllers\CategoryController;
-use App\Http\Controllers\ImportController;
-use App\Http\Controllers\user\CartController;
+use App\Http\Controllers\Admin\CategoryController;
+use App\Http\Controllers\Admin\ImportController;
+use App\Http\Controllers\User\CartController;
 
+use App\Http\Controllers\Admin\ProductController as AdminProductController;
+use App\Http\Controllers\User\ProductController as UserProductController;
 
 Route::middleware(['auth', 'verified'])->group(function () {
 
@@ -20,7 +21,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // 商品(管理者用)
     Route::prefix('products')
       ->group(function () {
-        Route::controller(ProductController::class)
+        Route::controller(AdminProductController::class)
           ->name('products.')
           ->group(function () {
             Route::get('/', 'index')->name('index');
@@ -63,7 +64,7 @@ Route::name('user.')->group(function () {
 
   // 商品(一般ユーザー用)
   Route::prefix('products')
-    ->controller(ProductController::class)
+    ->controller(UserProductController::class)
     ->name('products.')
     ->group(function () {
       Route::get('/', 'index')->name('index');
@@ -77,7 +78,8 @@ Route::name('user.')->group(function () {
     ->group(function () {
       Route::get('/', 'index')->name('index');
       Route::post('/add', 'add')->name('add');
-      Route::post('/update/{productId}', 'update')->name('update');
+      Route::post('/{productId}/increment', 'increment')->name('increment');
+      Route::post('/{productId}/decrement', 'decrement')->name('decrement');
       Route::delete('/remove/{productId}', 'remove')->name('remove');
       Route::get('/count', 'count')->name('count');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\ImportController;
+use App\Http\Controllers\user\CartController;
 
 
 Route::middleware(['auth', 'verified'])->group(function () {
@@ -67,6 +68,18 @@ Route::name('user.')->group(function () {
     ->group(function () {
       Route::get('/', 'index')->name('index');
       Route::get('/{uuid}', 'show')->name('show');
+    });
+
+  // カート機能
+  Route::prefix('cart')
+    ->controller(CartController::class)
+    ->name('cart.')
+    ->group(function () {
+      Route::get('/', 'index')->name('index');
+      Route::post('/add', 'add')->name('add');
+      Route::post('/update/{productId}', 'update')->name('update');
+      Route::delete('/remove/{productId}', 'remove')->name('remove');
+      Route::get('/count', 'count')->name('count');
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,10 +54,21 @@ Route::middleware(['auth', 'verified'])->group(function () {
 });
 
 
-// 一般ユーザー用ダッシュボード（認証不要）
-Route::get('/', function () {
-  return view('user.dashboard');
-})->name('user.dashboard');
+Route::name('user.')->group(function () {
+  // 一般ユーザー用ダッシュボード（認証不要）
+  Route::get('/', function () {
+    return view('user.dashboard');
+  })->name('dashboard');
+
+  // 商品(一般ユーザー用)
+  Route::prefix('products')
+    ->controller(ProductController::class)
+    ->name('products.')
+    ->group(function () {
+      Route::get('/', 'index')->name('index');
+      Route::get('/{uuid}', 'show')->name('show');
+    });
+});
 
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
表題の機能実装を行いました。
具体的には以下の内容です。

##一般ユーザー向け商品一覧（app/resources/views/user/products/index.blade.php）
・"/products"のルートにアクセスすると、一般ユーザーようの商品一覧が表示される
・商品一覧画面では、「商品詳細画面に遷移」「カートに追加」「商品の検索」が行えます。
・「カートに追加」すると、右上部にある「カートを見る」ボタンに数字アイコンが表示されます。(追加した商品の数が表示される)
・「カートを見る」をクリックすると、カート一覧画面に遷移します。

##カート一覧（app/resources/views/user/cart/index.blade.php）
・カートの情報はセッションに格納しています。
・カート一覧画面では、カート内の商品の増減と削除を行えます。
・カート内の商品の増減はJavaScriptを利用した非同期通信で実装しています。

ご確認よろしくお願いします。
